### PR TITLE
Fix error handling in service worker

### DIFF
--- a/service_worker.js
+++ b/service_worker.js
@@ -24,9 +24,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       .then((response) => {
         if (response.ok) {
           return response.text();
-        } else {
-          throw Promise.reject(response.statusText);
         }
+        // Reject with an Error so that the catch block receives a proper
+        // error object instead of a pending Promise which would never
+        // trigger the catch handler correctly.
+        throw new Error(response.statusText);
       })
       .then((data) => {
         sendResponse({


### PR DESCRIPTION
## Summary
- fix promise rejection logic in service worker

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687d1d27dd808325a17cbd27dec74dee